### PR TITLE
consumption of new cli in Sanity, Regression, restart and negative tests

### DIFF
--- a/ceph/nvmeof/cli/v2/base_cli.py
+++ b/ceph/nvmeof/cli/v2/base_cli.py
@@ -7,6 +7,7 @@ LOG = Log(__name__)
 
 KEY_MAP = {
     "subsystem": "nqn",
+    "host": "host_nqn",
     "host-nqn": "host_nqn",
     "rbd-pool": "rbd_pool",
     "rbd-image": "rbd_image_name",

--- a/ceph/nvmeof/cli/v2/namespace.py
+++ b/ceph/nvmeof/cli/v2/namespace.py
@@ -1,5 +1,11 @@
 from ceph.nvmeof.cli.v2.base_cli import BaseCLI
 
+from .common import substitute_keys
+
+KEY_MAP = {
+    "size": "rbd_image_size",
+}
+
 
 class Namespace:
     """NVMeoF Namespace operations."""
@@ -42,6 +48,7 @@ class Namespace:
         """Lists namespaces under subsystem."""
         return self.base.run_nvme_cli(self.name, "list", **kwargs)
 
+    @substitute_keys(KEY_MAP)
     def resize(self, **kwargs):
         """Resize namespace under subsystem."""
         return self.base.run_nvme_cli(self.name, "resize", **kwargs)

--- a/ceph/nvmeof/initiators/linux/nvme_cli.py
+++ b/ceph/nvmeof/initiators/linux/nvme_cli.py
@@ -120,7 +120,7 @@ class NVMeCLI(Cli):
                     for ctrl in subsys.get("Controllers", []):
                         if ctrl.get("ModelNumber", "").startswith(
                             "Ceph bdev Controller"
-                        ):
+                        ) and subsys.get("Namespaces"):
                             devices.append(dev)
             return devices
 

--- a/tests/nvmeof/test_ceph_nvmeof_high_availability.py
+++ b/tests/nvmeof/test_ceph_nvmeof_high_availability.py
@@ -9,10 +9,10 @@ from copy import deepcopy
 from ceph.ceph import Ceph
 from ceph.ceph_admin.common import fetch_method
 from ceph.ceph_admin.helper import check_service_exists
-from ceph.nvmeof.initiators.linux import Initiator
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
 from tests.nvmeof.workflows.ha import HighAvailability
+from tests.nvmeof.workflows.initiator import NVMeInitiator
 from tests.nvmeof.workflows.nvme_utils import (
     check_and_set_nvme_cli_image,
     delete_nvme_service,
@@ -87,15 +87,15 @@ def configure_subsystems(pool, ha, config):
     # Add Host access
     if config.get("allow_host"):
         nvmegwcli.host.add(
-            **{"args": {**sub_args, **{"host": repr(config["allow_host"])}}}
+            **{"args": {**sub_args, **{"host-nqn": repr(config["allow_host"])}}}
         )
 
     if config.get("hosts"):
         for host in config["hosts"]:
             initiator_node = get_node_by_id(ceph_cluster, host)
-            initiator = Initiator(initiator_node)
+            initiator = NVMeInitiator(initiator_node)
             host_nqn = initiator.nqn()
-            nvmegwcli.host.add(**{"args": {**sub_args, **{"host": host_nqn}}})
+            nvmegwcli.host.add(**{"args": {**sub_args, **{"host-nqn": host_nqn}}})
 
     # Add Namespaces
     if config.get("bdevs"):
@@ -129,7 +129,7 @@ def configure_subsystems(pool, ha, config):
 def disconnect_initiator(ceph_cluster, node):
     """Disconnect Initiator."""
     node = get_node_by_id(ceph_cluster, node)
-    initiator = Initiator(node)
+    initiator = NVMeInitiator(node)
     initiator.disconnect_all()
 
 

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -14,7 +14,6 @@ from ceph.ceph import Ceph, SocketTimeoutException
 from ceph.ceph_admin import CephAdmin
 from ceph.ceph_admin.helper import check_service_exists
 from ceph.ceph_admin.orch import Orch
-from ceph.nvmeof.initiators.linux import Initiator
 from ceph.parallel import parallel
 from ceph.rados.core_workflows import RadosOrchestrator
 from ceph.rados.monitor_workflows import MonitorWorkflows
@@ -181,7 +180,7 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
             conn_port = {"trsvcid": listener_port}
             _conn_cmd = {**_cmd_args, **conn_port}
             LOG.debug(initiator.connect(**_conn_cmd))
-            targets = initiator.list_spdk_drives()
+            targets = initiator.list_devices()
             rhel_version = initiator.distro_version()
             if not targets:
                 raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -395,7 +394,7 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
         conn_port = {"trsvcid": listener_port}
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         rhel_version = initiator.distro_version()
         if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -506,7 +505,7 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
         conn_port = {"trsvcid": listener_port}
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         rhel_version = initiator.distro_version()
         if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -533,7 +532,7 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
             raise Exception("Host did not started post reboot!!!!")
         initiator.configure()
         LOG.debug(initiator.connect(**_cmd_args))
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         rhel_version = initiator.distro_version()
         if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -634,7 +633,7 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
         conn_port = {"trsvcid": listener_port}
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         rhel_version = initiator.distro_version()
         if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -759,7 +758,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         conn_port = {"trsvcid": listener_port}
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         rhel_version = initiator.distro_version()
         if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
@@ -802,7 +801,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
                 LOG.info("Deletion of host is successful")
 
         sleep(20)
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         if targets[0].get("Subsystems"):
             namespaces_present = not (
                 all(
@@ -832,7 +831,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         # Check the existence of the NVMe namespaces
         nvmegwcli.host.add(**host_args)
         sleep(10)
-        targets = initiator.list_spdk_drives()
+        targets = initiator.list_devices()
         if targets[0].get("Subsystems"):
             namespaces_present = not (
                 all(

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -57,7 +57,6 @@ def test_ceph_83575812(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
     listener_port = find_free_port(gw_node)
     subsystem = dict()
     subsystem.update(
@@ -119,7 +118,6 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -155,7 +153,7 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
 
         config.update(initiator_cfg)
         client = get_node_by_id(ceph_cluster, config["node"])
-        initiator = Initiator(client)
+        initiator = NVMeInitiator(client)
         cmd_args = {
             "transport": "tcp",
             "traddr": nvmegwcli.node.ip_address,
@@ -241,7 +239,6 @@ def test_ceph_83575467(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -337,7 +334,6 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -380,7 +376,7 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
 
         config.update(initiator_cfg)
         client = get_node_by_id(ceph_cluster, config["node"])
-        initiator = Initiator(client)
+        initiator = NVMeInitiator(client)
 
         disc_port = {"trsvcid": 8009}
         _disc_cmd = {**cmd_args, **disc_port, **json_format}
@@ -449,7 +445,6 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -492,7 +487,7 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
 
         config.update(initiator_cfg)
         client = get_node_by_id(ceph_cluster, config["node"])
-        initiator = Initiator(client)
+        initiator = NVMeInitiator(client)
 
         initiator.disconnect_all()
         disc_port = {"trsvcid": 8009}
@@ -580,7 +575,6 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -612,7 +606,7 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
 
         config.update(initiator_cfg)
         client = get_node_by_id(ceph_cluster, config["node"])
-        initiator = Initiator(client)
+        initiator = NVMeInitiator(client)
         cmd_args = {
             "transport": "tcp",
             "traddr": nvmegwcli.node.ip_address,
@@ -704,9 +698,8 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
     client = get_node_by_id(ceph_cluster, config["initiator_node"])
-    initiator = Initiator(client)
+    initiator = NVMeInitiator(client)
     initiator_nqn = initiator.nqn()
 
     subsystem = dict()
@@ -781,6 +774,9 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
             ]
             _target = paths[0]
 
+        if not _target:
+            raise Exception("No paths")
+
         client.exec_command(sudo=True, cmd=f"mkdir {_dir}")
         client.exec_command(sudo=True, cmd=f"mkfs.ext4 {_target}")
         client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
@@ -790,8 +786,21 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         # Remove client host access to the namespaces
         # Check for the non-existence of nvme namespaces
         # Create a file to check IO failure on mount point
-        host_args = {"args": {"subsystem": subsystem["nqn"], "host": initiator_nqn}}
-        nvmegwcli.host.delete(**host_args)
+        LOG.info("Remove client host access to the namespaces")
+        try:
+            host_args = {
+                "args": {"subsystem": subsystem["nqn"], "host-nqn": initiator_nqn}
+            }
+            nvmegwcli.host.delete(**host_args)
+        except Exception as host_del_err:
+            if (
+                "Reconnecting the host would fail unless it is re-added to the subsystem"
+                not in str(host_del_err)
+            ):
+                raise Exception("Host deletion is failed")
+            else:
+                LOG.info("Deletion of host is successful")
+
         sleep(20)
         targets = initiator.list_spdk_drives()
         if targets[0].get("Subsystems"):
@@ -867,7 +876,6 @@ def test_ceph_83575813(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -886,7 +894,7 @@ def test_ceph_83575813(ceph_cluster, rbd, pool, config):
         "node": config["initiator_node"],
     }
     client = get_node_by_id(ceph_cluster, config["initiator_node"])
-    initiator = Initiator(client)
+    initiator = NVMeInitiator(client)
     try:
         configure_subsystems(ceph_cluster, rbd, pool, nvmegwcli, subsystem)
         name = generate_unique_id(length=4)
@@ -975,7 +983,6 @@ def test_ceph_83575814(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
     cephadm = CephAdmin(cluster=ceph_cluster, **config)
     mon_obj = MonitorWorkflows(node=cephadm)
     rados_obj = RadosOrchestrator(node=cephadm)
@@ -1065,7 +1072,6 @@ def test_ceph_83581753(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -1127,7 +1133,9 @@ def test_ceph_83581753(ceph_cluster, rbd, pool, config):
             )
             _ = nvmegwcli.namespace.set_qos(**qos_args_with_invalid_args)
         except Exception as err:
-            if "unrecognized arguments:" not in str(err):
+            if "unrecognized arguments:" not in str(
+                err
+            ) and "invalid command" not in str(err):
                 raise Exception("Set QoS was failed as expected due to invalid args.")
             LOG.info("Set QoS was failed as expected due to invalid args....")
         return 0
@@ -1164,7 +1172,6 @@ def test_ceph_83581945(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)
@@ -1280,7 +1287,6 @@ def test_ceph_83581755(ceph_cluster, rbd, pool, config):
         port=config.get("gw_port", 5500),
         gw_group=config.get("gw_group"),
     )
-    nvmegwcli.NVMEOF_CLI_IMAGE = cli_image
 
     subsystem = dict()
     listener_port = find_free_port(gw_node)

--- a/tests/nvmeof/workflows/exceptions.py
+++ b/tests/nvmeof/workflows/exceptions.py
@@ -1,0 +1,4 @@
+class NoDevicesFound(Exception):
+    """No devices Found in the node."""
+
+    pass

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -3,6 +3,7 @@ import json
 from ceph.ceph import CommandFailed
 from ceph.nvmeof.initiators.linux import Initiator
 from ceph.parallel import parallel
+from tests.nvmeof.workflows.exceptions import NoDevicesFound
 from utility.log import Log
 from utility.retry import retry
 from utility.utils import log_json_dump, run_fio
@@ -132,11 +133,12 @@ class NVMeInitiator(Initiator):
 
             LOG.debug(self.connect(**_conn_cmd))
 
+    @retry((NoDevicesFound))
     def list_devices(self):
         """List NVMe targets."""
         targets = self.list_spdk_drives()
         if not targets:
-            raise Exception(f"NVMe Targets not found on {self.node.hostname}")
+            raise NoDevicesFound(f"NVMe Targets not found on {self.node.hostname}")
         LOG.debug(targets)
         return targets
 


### PR DESCRIPTION
Logs:- 
http://magna002.ceph.redhat.com/cephci-jenkins/1st_sep_tier-4_nvmeof_neg_tests_new/
http://magna002.ceph.redhat.com/cephci-jenkins/tier-3_nvmeof_restart_operations_1st_setpt_1
http://magna002.ceph.redhat.com/cephci-jenkins/tier-3_nvmeof_restart_operations_1st_setpt_2
http://magna002.ceph.redhat.com/cephci-jenkins/1st_sept_tier-2_nvmeof_functional_Regression
http://magna002.ceph.redhat.com/cephci-jenkins/1st_sept_tier-2_nvmeof_e2e_fips
http://magna002.ceph.redhat.com/cephci-jenkins/tier-1_nvmeof_sanity_1st_set_2025


http://magna002.ceph.redhat.com/cephci-jenkins/1st_septier-2_nvmeof_e2e_fips_old
http://magna002.ceph.redhat.com/cephci-jenkins/1st_septier-1_nvmeof_sanity_old
http://magna002.ceph.redhat.com/cephci-jenkins/1st_septier-3_nvmeof_restart_operations_old
http://magna002.ceph.redhat.com/cephci-jenkins/1st_septier-4_nvmeof_neg_tests_old
http://magna002.ceph.redhat.com/cephci-jenkins/1st_sep_tier-1_nvmeof_ha_sanity