### PR TITLE
Incorporation of new cli changes in HA and multigateway group

### DIFF
--- a/ceph/nvmeof/cli/v2/base_cli.py
+++ b/ceph/nvmeof/cli/v2/base_cli.py
@@ -18,6 +18,7 @@ KEY_MAP = {
     "rw-megabytes-per-second": "rw_mbytes_per_second",
     "r-megabytes-per-second": "r_mbytes_per_second",
     "w-megabytes-per-second": "w_mbytes_per_second",
+    "level": "log_level",
 }
 
 

--- a/ceph/nvmeof/cli/v2/log_level.py
+++ b/ceph/nvmeof/cli/v2/log_level.py
@@ -5,7 +5,7 @@ class LogLevel:
 
     def __init__(self, base: BaseCLI) -> None:
         self.base = base
-        self.name = "log_level"
+        self.name = "spdk_log_level"
 
     def get(self, **kwargs):
         return self.base.run_nvme_cli(self.name, "get", **kwargs)

--- a/suites/tentacle/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-1_nvmeof_4-nvmeof-gwgroup_2gw_tests.yaml
@@ -94,7 +94,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode2
                 no-group-append: True
                 listener_port: 4420
@@ -103,7 +102,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -126,7 +124,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode4
                 no-group-append: True
                 listener_port: 4420
@@ -135,7 +132,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -158,7 +154,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node10
               - nqn: nqn.2016-06.io.spdk:cnode6
                 no-group-append: True
                 listener_port: 4420
@@ -167,7 +162,6 @@ tests:
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node11
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node10
@@ -227,21 +221,21 @@ tests:
               - node7
             subsystems:                       # Configure subsystems with all sub-entities
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -258,21 +252,21 @@ tests:
               - node9
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -289,6 +283,7 @@ tests:
               - node11
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
@@ -311,6 +306,7 @@ tests:
               - node13
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node12, node13]
                 allow_host: "*"
@@ -353,21 +349,21 @@ tests:
               - node7
             subsystems:                       # Configure subsystems with all sub-entities
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -384,21 +380,21 @@ tests:
               - node9
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -414,6 +410,7 @@ tests:
               - node11
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
@@ -435,6 +432,7 @@ tests:
               - node13
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node12, node13]
                 allow_host: "*"
@@ -478,21 +476,21 @@ tests:
               - node7
             subsystems:                                # Configure subsystems with all sub-entities
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -508,21 +506,21 @@ tests:
               - node9
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -538,6 +536,7 @@ tests:
               - node11
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
@@ -559,6 +558,7 @@ tests:
               - node13
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node12, node13]
                 allow_host: "*"
@@ -603,21 +603,21 @@ tests:
               - node7
             subsystems:                                # Configure subsystems with all sub-entities
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node6
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node6, node7]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node7
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node6
@@ -634,21 +634,21 @@ tests:
               - node9
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node8
               - nqn: nqn.2016-06.io.spdk:cnode17
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node8, node9]
                 allow_host: "*"
                 bdevs:
                   - count: 2
                     size: 4G
-                    lb_group: node9
             fault-injection-methods:                   # Failure induction
               - tool: systemctl
                 nodes: node8
@@ -665,6 +665,7 @@ tests:
               - node11
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node10, node11]
                 allow_host: "*"
@@ -687,6 +688,7 @@ tests:
               - node13
             subsystems:
               - nqn: nqn.2016-06.io.spdk:cnode16
+                no-group-append: True
                 listener_port: 4420
                 listeners: [node12, node13]
                 allow_host: "*"

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_1gwgroup_8gwnodes_ha_tests.yaml
@@ -91,34 +91,38 @@ tests:
           - node13
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode3
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -177,34 +181,38 @@ tests:
           - node13
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode3
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
@@ -263,34 +271,38 @@ tests:
           - node13
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode3
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode4
+            no-group-append: True
             serial: 1
             bdevs:
             - count: 2
-              size: 8G
+              size: 5G
             listener_port: 4420
             listeners: [node6, node7, node8, node9, node10, node11, node12, node13]
             allow_host: "*"

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_4nodes_gateway_ha_tests.yaml
@@ -150,18 +150,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 8
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -209,18 +199,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 8
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -266,18 +246,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 8
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -325,7 +295,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -338,7 +307,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -351,7 +319,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -364,7 +331,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -411,18 +377,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 8
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -473,18 +429,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 8
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -535,12 +481,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode1
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node6
-            - count: 2
-              size: 5G
-              lb_group: node7
+            - count: 4
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -551,12 +493,8 @@ tests:
           - nqn: nqn.2016-06.io.spdk:cnode2
             serial: 1
             bdevs:
-            - count: 2
-              size: 5G
-              lb_group: node8
-            - count: 2
-              size: 5G
-              lb_group: node9
+            - count: 4
+              size: 2G
             listener_port: 4420
             listeners:
               - node6
@@ -609,7 +547,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -622,7 +559,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -635,7 +571,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -648,7 +583,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -701,7 +635,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -714,7 +647,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -727,7 +659,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -740,7 +671,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -795,7 +725,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -808,7 +737,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -821,7 +749,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -834,7 +761,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6
@@ -885,7 +811,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node6
             listener_port: 4420
             listeners:
               - node6
@@ -898,7 +823,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node7
             listener_port: 4420
             listeners:
               - node6
@@ -911,7 +835,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node8
             listener_port: 4420
             listeners:
               - node6
@@ -924,7 +847,6 @@ tests:
             bdevs:
             - count: 2
               size: 5G
-              lb_group: node9
             listener_port: 4420
             listeners:
               - node6

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_gateway_operations.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_gateway_operations.yaml
@@ -1,6 +1,7 @@
 # Basic Ceph-NvmeoF sanity Test suite
 # cluster configuration file: conf/squid/nvmeof/ceph_nvmeof_sanity.yaml
 # Inventory: conf/inventory/rhel-9.6-server-x86_64-xlarge.yaml
+# TODO: We have issues for new cli so we need to re-look once issues are fixed
 
 tests:
 # Set up the cluster

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_hugepages_operations.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_hugepages_operations.yaml
@@ -91,7 +91,7 @@ tests:
               validate-spec-services: true
               specs:
                 - service_type: nvmeof
-                  service_id: rbd.group1
+                  service_id: rbd.gw_group1
                   placement:
                     nodes:
                       - node6
@@ -123,6 +123,7 @@ tests:
           - node7
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: true
             serial: 1
             bdevs:
               - count: 10
@@ -133,6 +134,7 @@ tests:
               - node7
             allow_host: "*"
           - nqn: nqn.2016-06.io.spdk:cnode2
+            no-group-append: true
             serial: 2
             bdevs:
               - count: 10

--- a/suites/tentacle/nvmeof/tier-2_nvmeof_qos_sanity_tests.yaml
+++ b/suites/tentacle/nvmeof/tier-2_nvmeof_qos_sanity_tests.yaml
@@ -88,6 +88,7 @@ tests:
           - gateway
         subsystems:                             # Configure subsystems with all sub-entities
           - nqn: nqn.2016-06.io.spdk:cnode1
+            no-group-append: true
             serial: 1
             bdevs:
               count: 1

--- a/tests/nvmeof/test_ceph_nvmeof_gateway.py
+++ b/tests/nvmeof/test_ceph_nvmeof_gateway.py
@@ -124,24 +124,7 @@ def initiators(ceph_cluster, gateway, config):
     LOG.debug(initiator.connect(**_conn_cmd))
 
     # List NVMe targets
-    targets = initiator.list_devices()
-    if not targets:
-        raise Exception(f"NVMe Targets not found on {client.hostname}")
-    LOG.debug(targets)
-
-    paths = []
-    for target in targets:
-        if "DevicePath" in target:
-            paths.append(target["DevicePath"])
-
-        elif "Subsystems" in target:
-            for subsys in target.get("Subsystems", []):
-                for ns in subsys.get("Namespaces", []):
-                    if "NameSpace" in ns:
-                        paths.append(f"/dev/{ns['NameSpace']}")
-
-    if not paths:
-        raise Exception("No paths found")
+    paths = initiator.list_devices()
 
     results = []
     io_args = {"size": "100%"}

--- a/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
+++ b/tests/nvmeof/test_ceph_nvmeof_loadbalancing.py
@@ -539,7 +539,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
                         # Prepare FIO Execution
                         namespaces = ha.fetch_namespaces(ha.gateways[0])
-                        ha.prepare_io_execution(gw, initiators)
+                        ha.prepare_io_execution(initiators)
 
                         # Check for targets at clients
                         ha.compare_client_namespace([i["uuid"] for i in namespaces])
@@ -560,7 +560,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
 
                         # Prepare FIO execution for existing namespaces
                         old_namespaces = ha.fetch_namespaces(gw)
-                        ha.prepare_io_execution(gw, initiators)
+                        ha.prepare_io_execution(initiators)
 
                         # Start IO Execution into already existing namespaces/nodes
                         LOG.info("Initiating IO before scale up ")
@@ -598,7 +598,7 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                                 )
 
                             # Prepare FIO Execution for new namespaces
-                            ha.prepare_io_execution(gw, initiators)
+                            ha.prepare_io_execution(initiators)
                             new_namespaces = ha.fetch_namespaces(ha.gateways[-1])
 
                             # Check for targets at clients for new namespaces

--- a/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_neg_tests.py
@@ -140,12 +140,12 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
         # Create image
         img = f"{name}-image"
         rbd.create_image(pool, img, "1G")
+        # TODO: Removing nsid because in 9.0 we have known issue
         ns_args = {
             "args": {
                 "subsystem": subsystem["nqn"],
                 "rbd-pool": pool,
                 "rbd-image": img,
-                "nsid": 1,
             }
         }
         nvmegwcli.namespace.add(**ns_args)
@@ -181,22 +181,10 @@ def test_ceph_83576084(ceph_cluster, rbd, pool, config):
             _conn_cmd = {**_cmd_args, **conn_port}
             LOG.debug(initiator.connect(**_conn_cmd))
             targets = initiator.list_devices()
-            rhel_version = initiator.distro_version()
-            if not targets:
-                raise Exception(f"NVMe Targets not found on {client.hostname}")
-            if rhel_version == "9.5":
-                _target = targets[0]["DevicePath"]
-            elif rhel_version == "9.6":
-                paths = [
-                    f"/dev/{ns['NameSpace']}"
-                    for device in targets
-                    for subsys in device.get("Subsystems", [])
-                    for ns in subsys.get("Namespaces", [])
-                ]
-                _target = paths[0]
+
             if not verify:
-                return _target
-            client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+                return targets[0]
+            client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
             client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
 
         target = check_client()
@@ -395,29 +383,16 @@ def test_ceph_83576085(ceph_cluster, rbd, pool, config):
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
         targets = initiator.list_devices()
-        rhel_version = initiator.distro_version()
-        if not targets:
-            raise Exception(f"NVMe Targets not found on {client.hostname}")
-        if rhel_version == "9.5":
-            _target = targets[0]["DevicePath"]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
-            _target = paths[0]
 
         client.exec_command(sudo=True, cmd=f"mkdir {_dir}")
-        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {_target}")
-        client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {targets[0]}")
+        client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         client.exec_command(sudo=True, cmd=f"cp /var/log/messages {_file}")
 
         for _ in "check":
             client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
             client.exec_command(sudo=True, cmd=f"umount {_dir}")
-            client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+            client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         LOG.info("Validation of CEPH-83576085 is successful.")
     except Exception as err:
         raise Exception(err)
@@ -506,23 +481,10 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
         targets = initiator.list_devices()
-        rhel_version = initiator.distro_version()
-        if not targets:
-            raise Exception(f"NVMe Targets not found on {client.hostname}")
-        if rhel_version == "9.5":
-            _target = targets[0]["DevicePath"]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
-            _target = paths[0]
 
         client.exec_command(sudo=True, cmd=f"mkdir {_dir}")
-        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {_target}")
-        client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {targets[0]}")
+        client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         client.exec_command(sudo=True, cmd=f"cp /var/log/messages {_file}")
         client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
 
@@ -533,20 +495,7 @@ def test_ceph_83576087(ceph_cluster, rbd, pool, config):
         initiator.configure()
         LOG.debug(initiator.connect(**_cmd_args))
         targets = initiator.list_devices()
-        rhel_version = initiator.distro_version()
-        if not targets:
-            raise Exception(f"NVMe Targets not found on {client.hostname}")
-        if rhel_version == "9.5":
-            _target = targets[0]["DevicePath"]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
-            _target = paths[0]
-        client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+        client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
         LOG.info("Validation of CEPH-83576087 is successful.")
     except Exception as err:
@@ -634,23 +583,10 @@ def test_ceph_83576093(ceph_cluster, rbd, pool, config):
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
         targets = initiator.list_devices()
-        rhel_version = initiator.distro_version()
-        if not targets:
-            raise Exception(f"NVMe Targets not found on {client.hostname}")
-        if rhel_version == "9.5":
-            _target = targets[0]["DevicePath"]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
-            _target = paths[0]
 
         client.exec_command(sudo=True, cmd=f"mkdir {_dir}")
-        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {_target}")
-        client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {targets[0]}")
+        client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         client.exec_command(sudo=True, cmd=f"cp /var/log/messages {_file}")
         client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
 
@@ -759,26 +695,9 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         _conn_cmd = {**_cmd_args, **conn_port}
         LOG.debug(initiator.connect(**_conn_cmd))
         targets = initiator.list_devices()
-        rhel_version = initiator.distro_version()
-        if not targets:
-            raise Exception(f"NVMe Targets not found on {client.hostname}")
-        if rhel_version == "9.5":
-            _target = targets[0]["DevicePath"]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
-            _target = paths[0]
-
-        if not _target:
-            raise Exception("No paths")
-
         client.exec_command(sudo=True, cmd=f"mkdir {_dir}")
-        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {_target}")
-        client.exec_command(sudo=True, cmd=f"mount {_target} {_dir}")
+        client.exec_command(sudo=True, cmd=f"mkfs.ext4 {targets[0]}")
+        client.exec_command(sudo=True, cmd=f"mount {targets[0]} {_dir}")
         client.exec_command(sudo=True, cmd=f"cp /var/log/messages {_file}")
         client.exec_command(sudo=True, cmd=f"ls -ltrh {_file}")
 
@@ -802,17 +721,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
 
         sleep(20)
         targets = initiator.list_devices()
-        if targets[0].get("Subsystems"):
-            namespaces_present = not (
-                all(
-                    not subsystem.get("Namespaces")
-                    for host in targets
-                    for subsystem in host.get("Subsystems", [])
-                )
-            )
-        else:
-            namespaces_present = targets
-        if namespaces_present:
+        if targets:
             raise Exception(f"NVMe Targets found on {client.hostname}!!!")
         LOG.info(f"NVMe targets not found on {client.hostname} as expected..")
         try:
@@ -832,17 +741,7 @@ def test_ceph_83575455(ceph_cluster, rbd, pool, config):
         nvmegwcli.host.add(**host_args)
         sleep(10)
         targets = initiator.list_devices()
-        if targets[0].get("Subsystems"):
-            namespaces_present = not (
-                all(
-                    not subsystem.get("Namespaces")
-                    for host in targets
-                    for subsystem in host.get("Subsystems", [])
-                )
-            )
-        else:
-            namespaces_present = targets
-        if not namespaces_present:
+        if not targets:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
         client.exec_command(
             sudo=True, cmd=f"dd if=/dev/zero of={_file}_test bs=1M count=1000"

--- a/tests/nvmeof/test_ceph_nvmeof_qos_tests.py
+++ b/tests/nvmeof/test_ceph_nvmeof_qos_tests.py
@@ -192,25 +192,15 @@ def teardown(ceph_cluster, rbd_obj, nvmegwcli, config):
 def trigger_fio(ceph_cluster, config, io_mode, key):
     results = []
     client = get_node_by_id(ceph_cluster, config["initiators"][0]["node"])
+    # TODO: change to nvme initiator
     initiator = Initiator(client)
 
     try:
         # List NVMe targets
-        targets = initiator.list_spdk_drives()
-        if not targets:
+        paths = initiator.list_spdk_drives()
+        if not paths:
             raise Exception(f"NVMe Targets not found on {client.hostname}")
-        LOG.debug(targets)
-
-        rhel_version = initiator.distro_version()
-        if rhel_version == "9.5":
-            paths = [target["DevicePath"] for target in targets]
-        elif rhel_version == "9.6":
-            paths = [
-                f"/dev/{ns['NameSpace']}"
-                for device in targets
-                for subsys in device.get("Subsystems", [])
-                for ns in subsys.get("Namespaces", [])
-            ]
+        LOG.debug(paths)
 
         with parallel() as p:
             for path in paths:

--- a/tests/nvmeof/test_nvme_cli.py
+++ b/tests/nvmeof/test_nvme_cli.py
@@ -88,7 +88,8 @@ def run(ceph_cluster: Ceph, **kwargs) -> int:
                 cfg["args"].update(
                     {"host-name": gw_node.hostname, "traddr": gw_node.ip_address}
                 )
-                cfg["base_cmd_args"] = {"server-address": gw_node.ip_address}
+                if nvmegwcli.cli_version != "v2":
+                    cfg["base_cmd_args"] = {"server-address": gw_node.ip_address}
             func = fetch_method(_cls, command)
             func(**cfg)
 

--- a/tests/nvmeof/test_nvmeof_gwgroup.py
+++ b/tests/nvmeof/test_nvmeof_gwgroup.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
 
 from ceph.ceph import Ceph
-from ceph.nvmeof.initiators.linux import Initiator
 from ceph.parallel import parallel
 from ceph.utils import get_node_by_id
 from tests.cephadm import test_nvmeof
 from tests.nvmeof.workflows.ha import HighAvailability
+from tests.nvmeof.workflows.initiator import NVMeInitiator
 from tests.nvmeof.workflows.nvme_utils import (
     check_and_set_nvme_cli_image,
     deploy_nvme_service,
@@ -159,7 +159,7 @@ def run_gateway_group_operations(ceph_cluster, gwgroup_config, config):
 def disconnect_initiator(ceph_cluster, node):
     """Disconnect Initiator."""
     node = get_node_by_id(ceph_cluster, node)
-    initiator = Initiator(node)
+    initiator = NVMeInitiator(node)
     initiator.disconnect_all()
 
 

--- a/tests/nvmeof/workflows/initiator.py
+++ b/tests/nvmeof/workflows/initiator.py
@@ -144,24 +144,22 @@ class NVMeInitiator(Initiator):
 
     def start_fio(self, io_size="100%"):
         """Start FIO on the all targets on client node."""
-        targets = self.list_devices()
-        paths = []
+        paths = self.list_devices()
         results = []
         io_args = {"size": io_size}
-        for target in targets:
-            if "DevicePath" in target:
-                paths.append(target["DevicePath"])
 
-            elif "Subsystems" in target:
-                for subsys in target.get("Subsystems", []):
-                    for ns in subsys.get("Namespaces", []):
-                        if "NameSpace" in ns:
-                            paths.append(f"/dev/{ns['NameSpace']}")
+        if not paths:
+            raise Exception("No paths found")
+
+        LOG.info(f"Paths found are {paths}")
 
         # Use max_workers to ensure all FIO processes can start simultaneously
         with parallel(max_workers=len(paths) + 4) as p:
             for path in paths:
                 _io_args = {}
+                # TODO: blockdiscard is temporary until solution is found
+                # for same image used for IO progression for twice
+                self.node.exec_command(cmd=f"blkdiscard {path}", sudo=True)
                 if io_args.get("test_name"):
                     test_name = f"{io_args['test_name']}-" f"{path.replace('/', '_')}"
                     _io_args.update({"test_name": test_name})


### PR DESCRIPTION
Resolved IO progression issue which was due to multiple FIO threads on the same namespaces by filtering the namespaces correctly
- Fix: Clearing up the namespaces before runing FIO command
- Removed invalid spanning of FIO threads in ha.run() Removed lb_group in the config files
Fixed list_spdk_drives() which is returning false nvme targets

